### PR TITLE
Fixing format issues

### DIFF
--- a/spec/nacha/batch_spec.cr
+++ b/spec/nacha/batch_spec.cr
@@ -5,8 +5,8 @@ describe Nacha::Batch do
     it "builds a full batch record" do
       example = <<-NACHA
       5220My Company                          1234567890WEBPAY OUT   221207221207   1071000500000001
-      62210264791931945123488995   0000062432            418           Billy Bonka  0000000000000001
-      622318092165493805838128300  0000035249            419           Milly Monka  0000000000000002
+      62210264791931945123488995   0000062432418            Billy Bonka             0000000000000001
+      622318092165493805838128300  0000035249419            Milly Monka             0000000000000002
       822000000200420740070000000000000000000976811234567890                         071000500000001
       NACHA
 
@@ -34,7 +34,7 @@ describe Nacha::Batch do
         amount: 62432, # $624.32
         individual_identification_number: "418",
         individual_name: "Billy Bonka",
-        trace_number: 1
+        trace_number: "1"
       )
       entry2 = Nacha::EntryDetail.new(
         transaction_code: :checking_credit,
@@ -43,7 +43,7 @@ describe Nacha::Batch do
         amount: 35249, # $352.49
         individual_identification_number: "419",
         individual_name: "Milly Monka",
-        trace_number: 2
+        trace_number: "2"
       )
       batch = Nacha::Batch.new(
         header: batch_header,

--- a/spec/nacha/entry_detail_spec.cr
+++ b/spec/nacha/entry_detail_spec.cr
@@ -3,7 +3,7 @@ require "../spec_helper"
 describe Nacha::EntryDetail do
   describe "build" do
     it "formats the data correctly" do
-      example = "62210264791931945123488995   0000062432            418           Billy Bonka  0000000000000001"
+      example = "62210264791931945123488995   0000062432418            Billy Bonka             0000000000000001"
       example.bytesize.should eq(Nacha::File::RECORD_SIZE)
 
       io = IO::Memory.new
@@ -14,6 +14,7 @@ describe Nacha::EntryDetail do
         amount: 62432, # $624.32
         individual_identification_number: "418",
         individual_name: "Billy Bonka",
+        trace_number: "1",
       )
       entry.build(io)
       io.to_s.should eq(example)

--- a/spec/nacha/file_spec.cr
+++ b/spec/nacha/file_spec.cr
@@ -7,8 +7,8 @@ describe Nacha::File do
       example = [
         "101 012345678 8723161272212071417A094101Bank of Specialty      My Company Name                ",
         "5220My Company                          1234567890WEBPAY OUT   221207221207   1071000500000001",
-        "62210264791931945123488995   0000062432            418           Billy Bonka  0000000000000001",
-        "622318092165493805838128300  0000035249            419           Milly Monka  0000000000000002",
+        "62210264791931945123488995   0000062432418            Billy Bonka             0000000000000001",
+        "622318092165493805838128300  0000035249419            Milly Monka             0000000000000002",
         "822000000200420740070000000000000000000976811234567890                         071000500000001",
         "9000001000001000000020042074007000000000000000000097681                                       ",
         "9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999",
@@ -49,7 +49,7 @@ describe Nacha::File do
         amount: 62432, # $624.32
         individual_identification_number: "418",
         individual_name: "Billy Bonka",
-        trace_number: 1
+        trace_number: "1"
       )
       entry2 = Nacha::EntryDetail.new(
         transaction_code: :checking_credit,
@@ -58,7 +58,7 @@ describe Nacha::File do
         amount: 35249, # $352.49
         individual_identification_number: "419",
         individual_name: "Milly Monka",
-        trace_number: 2
+        trace_number: "2"
       )
       batch = Nacha::Batch.new(
         header: batch_header,

--- a/src/nacha/entry_detail.cr
+++ b/src/nacha/entry_detail.cr
@@ -38,7 +38,7 @@ module Nacha
       @individual_name : String,
       @trace_number : String,
       @discretionary_data : String? = nil,
-      @addenda_included : Bool = false,
+      @addenda_included : Bool = false
     )
     end
 

--- a/src/nacha/entry_detail.cr
+++ b/src/nacha/entry_detail.cr
@@ -115,8 +115,8 @@ module Nacha
       io << check_digit
       io << @dfi_account_number[0..16].ljust(17, ' ')
       io << @amount.to_s.rjust(10, '0')
-      io << @individual_identification_number.rjust(15, ' ')
-      io << @individual_name.rjust(22, ' ')
+      io << @individual_identification_number.ljust(15, ' ')
+      io << @individual_name.ljust(22, ' ')
       io << @discretionary_data.to_s.ljust(2, ' ')
       io << (@addenda_included ? "1" : "0")
       io << formatted_trace_number

--- a/src/nacha/entry_detail.cr
+++ b/src/nacha/entry_detail.cr
@@ -25,9 +25,9 @@ module Nacha
     getter amount : Int32                            # Amount to send in cents
     getter individual_identification_number : String # The individual's ID
     getter individual_name : String                  # Their name
+    getter trace_number : String                     # Each entry detail should have a unique ID related to the batch
     getter discretionary_data : String?              # Optional extra 2 character data you want to add
     getter addenda_included : Bool
-    getter trace_number : Int64
 
     def initialize(
       @transaction_code : TransactionCode,
@@ -36,9 +36,9 @@ module Nacha
       @amount : Int32,
       @individual_identification_number : String,
       @individual_name : String,
+      @trace_number : String,
       @discretionary_data : String? = nil,
       @addenda_included : Bool = false,
-      @trace_number : Int64 = 1i64
     )
     end
 
@@ -79,7 +79,7 @@ module Nacha
           individual_name: individual_name.strip,
           discretionary_data: discretionary_data.strip.presence,
           addenda_included: addenda_record_indicator == '1',
-          trace_number: trace_number.to_i64,
+          trace_number: trace_number,
         )
       else
         raise_parse_error("Record Length", input.bytesize.to_s)
@@ -105,7 +105,7 @@ module Nacha
     end
 
     def formatted_trace_number : String
-      @trace_number.to_s.rjust(15, '0')
+      @trace_number.rjust(15, '0')
     end
 
     def build(io : IO) : IO


### PR DESCRIPTION
After looking at a few other libraries around I noticed (though, not consistent), the majority of them did a ljust on these fields. My guess is the banks don't actually care because they probably just strip white space and use the rest... but I'll keep with the majority.

Also, I need the `trace_number` to be a String because I need to append some other data which is numeric, but starting with "0"... this will just make it easier.